### PR TITLE
Use OClassName in OrientDBRecord as a cluster name if set, otherwise …

### DIFF
--- a/src/OrientDB.Net.ConnectionProtocols.Binary/Command/BinaryOrientDBTransaction.cs
+++ b/src/OrientDB.Net.ConnectionProtocols.Binary/Command/BinaryOrientDBTransaction.cs
@@ -41,7 +41,8 @@ namespace OrientDB.Net.ConnectionProtocols.Binary.Command
             if(!hasOrid)
             {
                 record.RecordORID = ORID.NewORID();
-                record.RecordORID.ClusterId = _clusterIdResolver(record.EntityName);                    
+                string className = string.IsNullOrEmpty(record.EntityClassName) ? record.EntityName : record.EntityClassName;
+                record.RecordORID.ClusterId = _clusterIdResolver(className);
             }
 
             if (_records.ContainsKey(record.RecordORID))

--- a/src/OrientDB.Net.ConnectionProtocols.Binary/Operations/DatabaseTransactionRequest.cs
+++ b/src/OrientDB.Net.ConnectionProtocols.Binary/Operations/DatabaseTransactionRequest.cs
@@ -3,7 +3,6 @@ using OrientDB.Net.ConnectionProtocols.Binary.Core;
 using OrientDB.Net.Core.Models;
 using OrientDB.Net.Core.Abstractions;
 using OrientDB.Net.ConnectionProtocols.Binary.Constants;
-using System.Text;
 
 namespace OrientDB.Net.ConnectionProtocols.Binary.Operations
 {
@@ -23,6 +22,10 @@ namespace OrientDB.Net.ConnectionProtocols.Binary.Operations
         public string EntityName
         {
             get { return _entity.GetType().Name; }
+        }
+
+        public string EntityClassName {
+            get { return _entity.OClassName; }
         }
 
         public ORID RecordORID


### PR DESCRIPTION
…fall back to the entity name