### PR TITLE
Handle OrientDBEntities which implement IDictionary

### DIFF
--- a/src/OrientDB.Net.ConnectionProtocols.Binary/Command/BinaryOrientDBTransaction.cs
+++ b/src/OrientDB.Net.ConnectionProtocols.Binary/Command/BinaryOrientDBTransaction.cs
@@ -41,7 +41,8 @@ namespace OrientDB.Net.ConnectionProtocols.Binary.Command
             if(!hasOrid)
             {
                 record.RecordORID = ORID.NewORID();
-                record.RecordORID.ClusterId = _clusterIdResolver(record.EntityName);                    
+                string className = string.IsNullOrEmpty(record.EntityClassName) ? record.EntityName : record.EntityClassName;
+                record.RecordORID.ClusterId = _clusterIdResolver(className);
             }
 
             if (_records.ContainsKey(record.RecordORID))

--- a/src/OrientDB.Net.ConnectionProtocols.Binary/Operations/DatabaseTransactionRequest.cs
+++ b/src/OrientDB.Net.ConnectionProtocols.Binary/Operations/DatabaseTransactionRequest.cs
@@ -3,7 +3,6 @@ using OrientDB.Net.ConnectionProtocols.Binary.Core;
 using OrientDB.Net.Core.Models;
 using OrientDB.Net.Core.Abstractions;
 using OrientDB.Net.ConnectionProtocols.Binary.Constants;
-using System.Text;
 
 namespace OrientDB.Net.ConnectionProtocols.Binary.Operations
 {
@@ -23,6 +22,10 @@ namespace OrientDB.Net.ConnectionProtocols.Binary.Operations
         public string EntityName
         {
             get { return _entity.GetType().Name; }
+        }
+
+        public string EntityClassName {
+            get { return _entity.OClassName; }
         }
 
         public ORID RecordORID

--- a/src/OrientDB.Net.Core/Models/OrientDBEntity.cs
+++ b/src/OrientDB.Net.Core/Models/OrientDBEntity.cs
@@ -21,38 +21,37 @@ namespace OrientDB.Net.Core.Models
             foreach (var key in data.Keys)
             {
                 var property = type.GetProperty(key);
-                if (property == null || !property.CanWrite) {
-                    continue;
-                }
-
-                OrientDBProperty orientDBPropertyAttribute = property.GetCustomAttribute<OrientDBProperty>(true);
-                if (!orientDBPropertyAttribute.Deserializable) {
-                    continue;
-                }
-
-                var propertyType = property.PropertyType;
-                if (data[key] == null)
-                {
-                    property.SetValue(this, null);
-                }
-                else if (data[key].GetType().GetInterfaces().Any(n => n == typeof(IConvertible)))
-                {
-                    object val = Convert.ChangeType(data[key], propertyType);
-                    property.SetValue(this, val);
-                }
-                else
-                {
-                    var objectType = property.PropertyType;
-
-                    if (objectType.Name == typeof(HashSet<>).Name || objectType.Name == typeof(List<>).Name)
-                    {
-                        ExtractList(data, objectType, key, property);
+                if (property != null) {
+                    if (!property.CanWrite) {
                         continue;
                     }
 
-                    if (objectType.Name == typeof(Dictionary<,>).Name)
-                    {
-                        ExtractDictionary(data, objectType, key, property);
+                    OrientDBProperty orientDBPropertyAttribute = property.GetCustomAttribute<OrientDBProperty>(true);
+                    if (!orientDBPropertyAttribute.Deserializable) {
+                        continue;
+                    }
+
+                    var propertyType = property.PropertyType;
+                    if (data[ key ] == null) {
+                        property.SetValue(this, null);
+                    } else if (data[ key ].GetType().GetInterfaces().Any(n => n == typeof(IConvertible))) {
+                        object val = Convert.ChangeType(data[ key ], propertyType);
+                        property.SetValue(this, val);
+                    } else {
+                        var objectType = property.PropertyType;
+
+                        if (objectType.Name == typeof(HashSet<>).Name || objectType.Name == typeof(List<>).Name) {
+                            ExtractList(data, objectType, key, property);
+                            continue;
+                        }
+
+                        if (objectType.Name == typeof(Dictionary<,>).Name) {
+                            ExtractDictionary(data, objectType, key, property);
+                        }
+                    }
+                } else {
+                    if (this is IDictionary<string, object>) {
+                        ((IDictionary<string, object>)this)[ key ] = data[ key ];
                     }
                 }
             }

--- a/src/OrientDB.Net.Core/Models/OrientDBEntity.cs
+++ b/src/OrientDB.Net.Core/Models/OrientDBEntity.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using OrientDB.Net.Core.Attributes;
 
 namespace OrientDB.Net.Core.Models
 {
@@ -20,7 +21,14 @@ namespace OrientDB.Net.Core.Models
             foreach (var key in data.Keys)
             {
                 var property = type.GetProperty(key);
-                if (property == null || !property.CanWrite) continue;
+                if (property == null || !property.CanWrite) {
+                    continue;
+                }
+
+                OrientDBProperty orientDBPropertyAttribute = property.GetCustomAttribute<OrientDBProperty>(true);
+                if (!orientDBPropertyAttribute.Deserializable) {
+                    continue;
+                }
 
                 var propertyType = property.PropertyType;
                 if (data[key] == null)

--- a/src/OrientDB.Net.Serializers.RecordCSVSerializer/OrientDBRecordCSVSerializer.cs
+++ b/src/OrientDB.Net.Serializers.RecordCSVSerializer/OrientDBRecordCSVSerializer.cs
@@ -11,6 +11,7 @@ using System.IO;
 using OrientDB.Net.Core.Abstractions;
 using OrientDB.Net.Core;
 using OrientDB.Net.Core.Models;
+using OrientDB.Net.Core.Attributes;
 
 namespace OrientDB.Net.Serializers.RecordCSVSerializer
 {
@@ -648,8 +649,12 @@ namespace OrientDB.Net.Serializers.RecordCSVSerializer
                         case "OClassId":
                             continue;
                         default:
-                            if ((!string.IsNullOrWhiteSpace(propertyInfo.Name)) && (propertyInfo.Name[0] != '@'))
-                            {
+                            bool isSerializable = (!string.IsNullOrWhiteSpace(propertyInfo.Name)) && (propertyInfo.Name[ 0 ] != '@');
+                            if (!isSerializable) {
+                                continue;
+                            }
+                            OrientDBProperty orientDBPropertyAttribute = propertyInfo.GetCustomAttribute<OrientDBProperty>(true);
+                            if (orientDBPropertyAttribute == null || orientDBPropertyAttribute.Serializable) {
                                 if (stringBuilder.Length > 0)
                                     stringBuilder.Append(",");
 


### PR DESCRIPTION
We have a DictionaryOrientDBEntity but that one doesn't really behave like a document which I assume it was supposed to. It will correctly "hydrate" but when serialized it will put all its key/value entries in a subobject called "Fields".
Rather than treating the "document" case by an entity which _has_ a dictionary I think we should treat it by entities which _are_ dictionaries.